### PR TITLE
fix: update getDeviceDataFromDataCollector method to accept options

### DIFF
--- a/ios/ExpoBraintree.mm
+++ b/ios/ExpoBraintree.mm
@@ -14,7 +14,7 @@ RCT_EXTERN_METHOD(tokenizeCardData:(NSDictionary*)options
                  withResolver:(RCTPromiseResolveBlock)resolve
                  withRejecter:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(getDeviceDataFromDataCollector:(NSString*)clientToken
+RCT_EXTERN_METHOD(getDeviceDataFromDataCollector:(NSDictionary*)options
                  withResolver:(RCTPromiseResolveBlock)resolve
                  withRejecter:(RCTPromiseRejectBlock)reject)
 


### PR DESCRIPTION
Hi!
This PR addresses an issue where the `getDeviceDataFromDataCollector` method expects a string as input (the clientKey), but an object is being passed instead. 

The fix ensures that the correct data type (string) is passed to the method, resolving the type mismatch.

Thanks!